### PR TITLE
Add support for webp and global nginx headers for cached pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ This project is sponsored by SatelliteWP, a [WordPress maintenance service](http
   1. [Before You Start](#before)
   1. [Installation](#installation)
   1. [Configuration](#configuration)
+  1. [WP-Rocket Configuration](#wp-rocket)
   1. [Debug](#debug)
   1. [FAQ](#css)
   1. [License](#license)
 
 ## <a name='contributors'>Contributors</a>
 
-The configuration was created by [Maxime Jobin](https://www.maximejobin.com) ([@maximejobin](https://github.com/maximejobin)) and is now maintained by [SatelliteWP](https://www.satellitewp.com/en?utm_source=rocket-nginx). 
+The configuration was created by [Maxime Jobin](https://www.maximejobin.com) ([@maximejobin](https://github.com/maximejobin)) and is now maintained by [SatelliteWP](https://www.satellitewp.com/en?utm_source=rocket-nginx).
+
+Improved handling of global headers and WEBP support by [Jan Thiel](https://github.com/janthiel) 
 
 ## <a name='before'>Before You Start</a>
 As the configuration's goal is to serve cached files directly without having to execute any PHP from WordPress, this may cause your scheduled jobs to not be called.  As you may already know, WP-Cron jobs are not real cron jobs and are executed only when you have visits on your site.
@@ -45,11 +48,11 @@ Make sure you test that your tasks still run after this change!
 
 ## <a name='installation'>Installation</a>
 
-In order to use the script, you must include it in your actual configuration.  If your WordPress website is not yet configured to run with Nginx, you can check the [Nginx configuration for WordPress](https://github.com/satellitewp/rocket-nginx/wiki/Nginx-configuration-for-WordPress) documentation.
+In order to use the script, you must include it in your actual nginx configuration. If your WordPress website is not yet configured to run with Nginx, you can check the [Nginx configuration for WordPress](https://github.com/satellitewp/rocket-nginx/wiki/Nginx-configuration-for-WordPress) documentation.
 
-Only one instance of Rocket-Nginx is needed for all your WordPress websites using WP-Rocket. That said, you can generate as many configuration files as needed.
+Only one config files you generated with Rocket-Nginx is needed for all your WordPress websites using WP-Rocket. That said, you can generate as many configuration files as needed.
 
-You can create a folder `rocket-nginx` directory in your Nginx configuration directory. If you are using Ubuntu, your Nginx configuration (nginx.conf) should be found in: `/etc/nginx/`.
+If you are using Ubuntu, Debian or RHEL/CentOS your Nginx configuration (nginx.conf) should be found in: `/etc/nginx/`.
 
 To install, you can:
   ```
@@ -57,15 +60,15 @@ To install, you can:
   git clone https://github.com/satellitewp/rocket-nginx.git
   ```
 
-Since version 2.0, the configuration must be generated. To generate the default configuration, you must rename the disabled ini file and run the configuration parser:
+The configuration has to be generated. To generate the default configuration, you have to rename the disabled ini file and run the configuration parser:
 ```
 cd rocket-nginx
 cp rocket-nginx.ini.disabled rocket-nginx.ini
 php rocket-parser.php
 ```
-This will generate the `default.conf` configuration that can be included for all websites.  If you need to alter the default configuration, you can edit the ini file and add another section at the bottom of the file.
+This will generate the `default.conf` configuration that can be included for all websites. If you need to alter the default configuration, you can edit the ini file and add another section at the bottom of the file.
 
-Then, in your configuration file, you must [include](https://nginx.org/en/docs/ngx_core_module.html#include) the configuration. If your websites configurations are in `/etc/nginx/sites-available`, you need to alter your configuration:
+Then, in your configuration file, you have to [include](https://nginx.org/en/docs/ngx_core_module.html#include) the configuration. If your websites configurations are in `/etc/nginx/sites-available`, you need to alter your configuration:
 
 ```
 server {
@@ -118,6 +121,11 @@ Finally, **each time** you generate (or regenerate) the configurations files, yo
 
     `service nginx reload`
 
+## <a name='wp-rocket'>WP-Rocket Configuration</a>
+
+You just have to activate the plugin on your site to have caching enabled. 
+
+If you want to have WEBP support for your website, you have to enable the "WEBP Feature" within WP-Rocket in the *Media* section. You still require a tool to actually generating the webp files for you.
 
 ## <a name='debug'>Debug</a>
 You may want to check if your files are served directly by Nginx and not calling any PHP. To do that, open the `rocket-nginx.ini` file and change the debug value from:
@@ -142,7 +150,7 @@ Reasons for not serving a cached file:
   * **Maintenance mode**: The .maintenance file was found. Therefore, let's WordPress handle what should be displayed.
   * **Cookie**: A specific cookie was found and tells to not serve the cached page (e.g. user is logged in, post with password).
   * **Specific mobile cache activated**: If you activated specific cache (one for mobile and one for desktop) in WP-Rocket, HTML files (pages, posts, ...) won't be served directly because Rocket-Nginx cannot know if the request was made by mobile or desktop device.
-  * **File not cached**: No cached file was found for that request.
+  * **Cache file not found**: No cached file was found for that request.
 
 ## <a name='faq'>FAQ</a>
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is sponsored by SatelliteWP, a [WordPress maintenance service](http
   1. [Configuration](#configuration)
   1. [WP-Rocket Configuration](#wp-rocket)
   1. [Debug](#debug)
-  1. [FAQ](#css)
+  1. [FAQ](#faq)
   1. [License](#license)
 
 ## <a name='contributors'>Contributors</a>

--- a/rocket-nginx.ini.disabled
+++ b/rocket-nginx.ini.disabled
@@ -1,7 +1,7 @@
 ; Rocket-Nginx configuration file
 ; Author: Maxime Jobin
-; URL: https://github.com/maximejobin/rocket-nginx
-; Version: 2.1.1
+; URL: https://github.com/SatelliteWP/rocket-nginx
+; Version: 2.2.0
 
 ; Default configuration
 [default]
@@ -41,20 +41,6 @@ cookie_invalidate[] = "comment_author_email_"
 ; Format: name "value"
 ; Example: http_header[My-Domain] = "mydomain.com"
 
-; HTTP(S) gzipped headers
-; Custom headers can be added to the requests that serve already gzipped cached files (pages, posts, custom 
-; post types,etc). Brackets must be added at the end of the gzip_header variable name.  That way, multiple 
-; headers can be added.
-; Format: name "value"
-; Example: gzip_header[Is-Already-Gzipped] = "Yes"
-
-; HTTP(S) non gzipped headers
-; Custom headers can be added to the requests that serve cached files (pages, posts, custom post types, 
-; etc). Brackets must be added at the end of the gzip_header variable name.  That way, multiple headers
-; can be added.
-; Format: name "value"
-; Example: nongzip_header[Is-Compressed] = "Yes"
-
 ; HTTP Strict Transport Security (HSTS)
 ; HTTP Strict Transport Security (HSTS) is an opt-in security enhancement that is specified by a web 
 ; application through the use of a special response header. Once a supported browser receives this 
@@ -84,7 +70,7 @@ header_hsts = "max-age=31536000; includeSubDomains"
 ; Medias extensions for images, icons, fonts and other cachable medias. All extensions are separated
 ; by pipes (|).
 ; Default value: ico|gif|jpe?g|png|svg|eot|otf|woff|woff2|ttf|ogg
-media_extensions = "ico|gif|jpe?g|png|svg|eot|otf|woff|woff2|ttf|ogg"
+media_extensions = "ico|gif|jpe?g|png|svg|webp|eot|otf|woff|woff2|ttf|ogg"
 
 ; Medias headers
 ; Custom headers can be added to the medias requests for 

--- a/rocket-nginx.tmpl
+++ b/rocket-nginx.tmpl
@@ -7,10 +7,10 @@
 # Author: Maxime Jobin
 # URL: https://github.com/maximejobin/rocket-nginx
 #
-# Tested with WP-Rocket version: 3.0.5.1
-# Tested with NGINX: 1.15 (mainline)
+# Tested with WP-Rocket version: 3.4.0.5
+# Tested with NGINX: 1.16.1 (mainline)
 #
-# Version 2.1.1
+# Version 2.2.0
 #
 ###################################################################################################
 
@@ -28,6 +28,11 @@ set $rocket_is_bypassed "No";		# Header text added to check if the bypass worked
 set $rocket_reason "";				# Reason why cache file was not used. If cache file is used, what file was used
 set $rocket_https_prefix "";		# HTTPS prefix to use when cached files are using HTTPS
 set $rocket_hsts 0;					# Is HSTS is off (0) by default. Will be turned on (1) if request is HTTPS
+set $rocket_webp_prefix "";         # Allow to use the WEBP generated cache files if the browser supports it
+
+set $rocket_vary "Accept-Encoding, Cookie";                         # Default Vary header
+set $rocket_cache_control "#!# HTML_CACHE_CONTROL #!#";    # Default cache-control header
+set $rocket_content_encoding "";                                    # Default content encoding
 
 # HSTS value
 set $rocket_hsts_value "#!# HEADER_HSTS #!#";
@@ -46,6 +51,11 @@ if ($http_accept_encoding ~ br) {
 	set $rocket_encryption "";
 }
 
+# Is webp supported by the client ?
+if ($http_accept ~ webp) {
+    set $rocket_webp_prefix "-webp";
+}
+
 # Is SSL request ?
 if ($https = "on") {
 	set $rocket_https_prefix "-https";
@@ -57,11 +67,14 @@ if ($rocket_hsts = "0") {
 	set $rocket_hsts_value "";
 }
 
-# File/URL to return IF we must bypass WordPress
+## File/URL to return IF we must bypass WordPress
 # Desktop: index.html or index-https.html
 # Mobile:  index-mobile.html or index-mobile-https.html
+# WEBP:    index-webp.html or index-https-webp.html
 set $rocket_end "/cache/wp-rocket/$http_host/$request_uri/index$rocket_https_prefix.html$rocket_encryption";
+set $rocket_end_webp "/cache/wp-rocket/$http_host/$request_uri/index$rocket_https_prefix$rocket_webp_prefix.html$rocket_encryption";
 set $rocket_url "/#!# WP_CONTENT_URI #!#$rocket_end";
+set $rocket_url_webp "/#!# WP_CONTENT_URI #!#$rocket_end_webp";
 set $rocket_file "$document_root/#!# WP_CONTENT_URI #!#$rocket_end";
 set $rocket_mobile_detection "$document_root/#!# WP_CONTENT_URI #!#/cache/wp-rocket/$http_host/$request_uri/.mobile-active";
 
@@ -100,7 +113,7 @@ if (-f "$rocket_mobile_detection") {
 # Do not bypass if the cached file does not exist
 if (!-f "$rocket_file") {
 	set $rocket_bypass 0;
-	set $rocket_reason "File not cached";
+	set $rocket_reason "Cache file not found";
 }
 
 # If the bypass token is still on, let's bypass WordPress with the cached URL
@@ -115,22 +128,24 @@ if ($rocket_debug = 0) {
 	set $rocket_file "";
 }
 
+# Clear caching headers and cache urls if bypass is disabled
+if ($rocket_bypass = 0) {
+    set $rocket_vary "";
+    set $rocket_cache_control "";
+    set $rocket_content_encoding "";
+    set $rocket_url "NULL";
+    set $rocket_url_webp "NULL";
+}
+
 # If the bypass token is still on, rewrite according to the file linked to the request
-if ($rocket_bypass = 1) {
-	rewrite .* "$rocket_url" last;
+location / {
+    # Try to access the webp file first, then default caching file and as a fallback default WordPress w/o caching
+    try_files $rocket_url_webp $rocket_url $uri $uri/ /index.php?$args;
 }
 
 # Add header to HTML cached files
 location ~ /#!# WP_CONTENT_URI #!#/cache/wp-rocket/.*html$ {
 	etag on;
-	add_header Vary "Accept-Encoding, Cookie";
-	add_header Cache-Control "#!# HTML_CACHE_CONTROL #!#";
-	add_header X-Rocket-Nginx-Serving-Static $rocket_is_bypassed;
-	add_header X-Rocket-Nginx-Reason $rocket_reason;
-	add_header X-Rocket-Nginx-File $rocket_file;
-	add_header Strict-Transport-Security "$rocket_hsts_value";
-	#!# HEADER_HTTP #!#
-	#!# HEADER_NON_GZIP #!#
 }
 
 # Do not gzip cached files that are already gzipped
@@ -139,24 +154,19 @@ location ~ /#!# WP_CONTENT_URI #!#/cache/wp-rocket/.*_gzip$ {
 	gzip off;
 	types {}
 	default_type text/html;
-	add_header Content-Encoding gzip;
-	add_header Vary "Accept-Encoding, Cookie";
-	add_header Cache-Control "#!# HTML_CACHE_CONTROL #!#";
-	add_header X-Rocket-Nginx-Serving-Static $rocket_is_bypassed;
-	add_header X-Rocket-Nginx-Reason $rocket_reason;
-	add_header X-Rocket-Nginx-File $rocket_file;
-	add_header Strict-Transport-Security "$rocket_hsts_value";
-	#!# HEADER_HTTP #!#
-	#!# HEADER_GZIP #!#
 }
+
+# Setting the caching headers
+add_header Content-Encoding $rocket_content_encoding;
+add_header Vary $rocket_vary;
+add_header Cache-Control $rocket_cache_control;
+add_header Strict-Transport-Security "$rocket_hsts_value";
+#!# HEADER_HTTP #!#
 
 # Debug header (when file is not cached)
 add_header X-Rocket-Nginx-Serving-Static $rocket_is_bypassed;
 add_header X-Rocket-Nginx-Reason $rocket_reason;
 add_header X-Rocket-Nginx-File $rocket_file;
-
-# No HSTS header added here. We suppose it's correctly added in the site configuration
-
 
 ###################################################################################################
 # BROWSER CSS CACHE
@@ -164,7 +174,7 @@ add_header X-Rocket-Nginx-File $rocket_file;
 location ~* \.css$ {
 	etag on;
 	gzip_vary on;
-	expires 30d;
+	expires 90d;
 	#!# HEADER_CSS #!#
 }
 
@@ -175,7 +185,7 @@ location ~* \.css$ {
 location ~* \.js$ {
 	etag on;
 	gzip_vary on;
-	expires 30d;
+	expires 90d;
 	#!# HEADER_JS #!#
 }
 
@@ -185,6 +195,6 @@ location ~* \.js$ {
 #
 location ~* \.(#!# EXTENSION_MEDIAS #!#)$ {
 	etag on;
-	expires 30d;
+	expires 90d;
 	#!# HEADER_MEDIAS #!#
 }

--- a/rocket-parser.php
+++ b/rocket-parser.php
@@ -101,20 +101,6 @@ class RocketParser {
         $header_http = $this->getGeneratedHeaders($section['http_header']);
       }
       $output = str_replace('#!# HEADER_HTTP #!#', $header_http, $output);
-      
-      // GZIP headers
-      $gzip_header = '';
-      if (isset($section['gzip_header']) && is_array($section['gzip_header'])) {
-        $gzip_header = $this->getGeneratedHeaders($section['gzip_header']);
-      }
-      $output = str_replace('#!# HEADER_GZIP #!#', $gzip_header, $output);
-
-      // Non-GZIP headers
-      $nongzip_header = '';
-      if (isset($section['nongzip_header']) && is_array($section['nongzip_header'])) {
-        $nongzip_header = $this->getGeneratedHeaders($section['nongzip_header']);
-      }
-      $output = str_replace('#!# HEADER_NON_GZIP #!#', $nongzip_header, $output);
 
       // CSS headers
       $css_header = '';

--- a/rocket-parser.php
+++ b/rocket-parser.php
@@ -6,9 +6,9 @@
 * website with the cache plugin WP-Rocket (http://wp-rocket.me)
 *
 * Author: Maxime Jobin
-* URL: https://github.com/maximejobin/rocket-nginx
+* URL: https://github.com/SatelliteWP/rocket-nginx
 *
-* Version 2.1.1
+* Version 2.2.0
 *
 **************************************************************************************************/
 


### PR DESCRIPTION
- Added support for the WP-Rocket WEBP feature
- moved add_headers directives from the location blocks to global level to allow global headers to coexist with wp-rocket headers
- switched from rewrite to much faster try_files. This saves another expensive -f check for the webp file
- Deprecated HEADER_GZIP and HEADER_NON_GZIP
- Increased expiry to 90d to make Google Lighthouse happy
- extended and fixed README file
- version bump to 2.2.0