### PR TITLE
Don't enable HSTS by default

### DIFF
--- a/rocket-nginx.ini.disabled
+++ b/rocket-nginx.ini.disabled
@@ -65,7 +65,7 @@ cookie_invalidate[] = "comment_author_email_"
 
 ; HSTS header value
 ; Default value: max-age=31536000; includeSubDomains
-header_hsts = "max-age=31536000; includeSubDomains"
+; header_hsts = "max-age=31536000; includeSubDomains"
 
 ; CSS headers
 ; Custom headers can be added to the CSS requests.


### PR DESCRIPTION
Enabling HSTS should be opt-in and informed choice by the website owner and not a default enabled setting in this projects default config. It can have critical consequnes for websites especially when `includeSubDomains` is used.

  